### PR TITLE
Minor typo fix and consistency update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Everything's still just in my head and therefore almost anything is a subject to
 Grumpy Visitors relies on `git-lfs` to fetch game assets (images, etc.) See [git-lfs](https://github.com/git-lfs/git-lfs) for installation instructions if you don't already have it on your system. Then:
 
 ```bash
-git lfs install # (if this is your first time running git lfs)
+git lfs install # if this is your first time running git lfs
 git lfs pull
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ git lfs pull
 ## Building
 ```bash
 cargo build -p gv_server # if you want to host a server for multiplayer
-cargo -Z features=itarget build -p gb_client
+cargo -Z features=itarget build -p gv_client
 ```
 
 **Please note** that specifying just a binary without a package (`cargo build --bin gv_server`) won't work.


### PR DESCRIPTION
Fixes #52 

- Changed `gb_client` to `gv_client` in Building section of README.md
- Removed parentheses from `lfs install` in README.md to make it consistent with the Building section comment

Minor things, but it's a start! I hope to start work on #51 soon.