### PR TITLE
Allow configuration of window action bindings

### DIFF
--- a/libs/client_shared/src/settings.rs
+++ b/libs/client_shared/src/settings.rs
@@ -1,7 +1,8 @@
 use amethyst::{
     config::Config,
-    input::{Bindings, StringBindings},
+    input::{Bindings, Button, StringBindings},
     window::{DisplayConfig, MonitorIdent},
+    winit::{VirtualKeyCode},
 };
 use directories::ProjectDirs;
 use ron::ser::PrettyConfig;
@@ -104,6 +105,17 @@ impl Settings {
 
     pub fn bindings(&self) -> &Bindings<StringBindings> {
         &self.bindings
+    }
+
+    pub fn get_action_keycode(&self, action: &'static str) -> Option<VirtualKeyCode> {
+        if let Some(button) = self.bindings.action_bindings(action).next() {
+            return match button[0] {
+                Button::Key(key) => Some(key),
+                _ => None,
+            };
+        } else {
+            return None;
+        }
     }
 
     pub fn display(&self) -> &DisplayConfig {

--- a/libs/client_shared/src/utils/window_event_handler.rs
+++ b/libs/client_shared/src/utils/window_event_handler.rs
@@ -14,8 +14,8 @@ pub fn handle_window_event(world: &World, event: &StateEvent) -> Option<SimpleTr
     let mut application_settings = world.fetch_mut::<Settings>();
     let display = application_settings.display();
 
-    let toggle_fullscreen = application_settings.get_action_keycode("toggle_fullscreen")?;
-    let log_dimensions = application_settings.get_action_keycode("log_dimensions")?;
+    let toggle_fullscreen = application_settings.get_action_keycode("toggle_fullscreen");
+    let log_dimensions = application_settings.get_action_keycode("log_dimensions");
 
     if let StateEvent::Window(event) = &event {
         if is_close_requested(&event) {
@@ -27,7 +27,7 @@ pub fn handle_window_event(world: &World, event: &StateEvent) -> Option<SimpleTr
                 event: winit::WindowEvent::KeyboardInput { input, .. },
                 ..
             } if input.state == ElementState::Released => {
-                if input.virtual_keycode == Some(toggle_fullscreen) {
+                if input.virtual_keycode == toggle_fullscreen {
                     let window = world.fetch_mut::<Window>();
 
                     let monitor_id = if display.fullscreen.is_some() {
@@ -43,7 +43,7 @@ pub fn handle_window_event(world: &World, event: &StateEvent) -> Option<SimpleTr
                         .save_fullscreen(fullscreen_monitor_ident)
                         .expect("Failed to save settings");
                     window.set_fullscreen(monitor_id);
-                } else if input.virtual_keycode == Some(log_dimensions) {
+                } else if input.virtual_keycode == log_dimensions {
                     let screen_dimensions = world.fetch::<ScreenDimensions>();
                     println!(
                         "{}:{}",

--- a/libs/client_shared/src/utils/window_event_handler.rs
+++ b/libs/client_shared/src/utils/window_event_handler.rs
@@ -1,10 +1,10 @@
 use amethyst::{
     ecs::{Join, World},
-    input::is_close_requested,
+    input::{is_close_requested},
     prelude::{SimpleTrans, StateEvent, Trans, WorldExt},
     renderer::{camera::Projection, Camera},
     window::{MonitorIdent, ScreenDimensions, Window},
-    winit::{self, ElementState, VirtualKeyCode},
+    winit::{self, ElementState},
 };
 
 use crate::settings::Settings;
@@ -13,6 +13,9 @@ use crate::settings::Settings;
 pub fn handle_window_event(world: &World, event: &StateEvent) -> Option<SimpleTrans> {
     let mut application_settings = world.fetch_mut::<Settings>();
     let display = application_settings.display();
+
+    let toggle_fullscreen = application_settings.get_action_keycode("toggle_fullscreen")?;
+    let log_dimensions = application_settings.get_action_keycode("log_dimensions")?;
 
     if let StateEvent::Window(event) = &event {
         if is_close_requested(&event) {
@@ -23,8 +26,8 @@ pub fn handle_window_event(world: &World, event: &StateEvent) -> Option<SimpleTr
             winit::Event::WindowEvent {
                 event: winit::WindowEvent::KeyboardInput { input, .. },
                 ..
-            } if input.state == ElementState::Released => match input.virtual_keycode {
-                Some(VirtualKeyCode::F11) => {
+            } if input.state == ElementState::Released => {
+                if input.virtual_keycode == Some(toggle_fullscreen) {
                     let window = world.fetch_mut::<Window>();
 
                     let monitor_id = if display.fullscreen.is_some() {
@@ -40,8 +43,7 @@ pub fn handle_window_event(world: &World, event: &StateEvent) -> Option<SimpleTr
                         .save_fullscreen(fullscreen_monitor_ident)
                         .expect("Failed to save settings");
                     window.set_fullscreen(monitor_id);
-                }
-                Some(VirtualKeyCode::F10) => {
+                } else if input.virtual_keycode == Some(log_dimensions) {
                     let screen_dimensions = world.fetch::<ScreenDimensions>();
                     println!(
                         "{}:{}",
@@ -49,7 +51,6 @@ pub fn handle_window_event(world: &World, event: &StateEvent) -> Option<SimpleTr
                         screen_dimensions.height()
                     );
                 }
-                _ => {}
             },
 
             winit::Event::WindowEvent {

--- a/resources/bindings_config.ron
+++ b/resources/bindings_config.ron
@@ -4,6 +4,8 @@
         "horizontal": Emulated(pos: Key(D), neg: Key(A)),
     },
     actions: {
+        "toggle_fullscreen": [[Key(F11)]],
+        "log_dimensions": [[Key(F10)]],
         // Shortcuts for debug info settings.
         "toggle_healthbars": [[Key(Slash)]],
         "toggle_network_debug_info": [[Key(Period)]],


### PR DESCRIPTION
Fixes #29 

- Added new default bindings in `bindings_config.ron` to window actions
    - `"toggle_fullscreen"`: `F11`
    - `"log_dimensions"`: `F10`
- Add function `get_action_keycode` to `settings.rs`
    - Takes a `str` of the action name
    - Returns the corresponding `Some(VirtualKeyCode)` if the action binding exists and is a `Key`, else `None`
- Refactored `window_event_handler.rs` to use an `if` statement for binding checks rather than match
    - Now uses the bindings from `get_action_keycode`
    - `if` allows bindings not known at compile-time, which seems not to work with `match` (Correct me if I'm wrong)
