### PR TITLE
Add MultiplayerRoomPlayer to StartGame payload

### DIFF
--- a/bins/client/src/ecs/systems/client_network.rs
+++ b/bins/client/src/ecs/systems/client_network.rs
@@ -16,7 +16,7 @@ use gv_core::{
     ecs::{
         components::NetConnectionModel,
         resources::{
-            net::{MultiplayerGameState, PlayersNetStatus},
+            net::{MultiplayerGameState, MultiplayerRoomPlayer, PlayersNetStatus},
             world::{
                 FramedUpdates, PlayerActionUpdates, ReceivedPlayerUpdate,
                 ReceivedServerWorldUpdate, ServerWorldUpdate, PAUSE_FRAME_THRESHOLD,
@@ -39,7 +39,6 @@ use gv_game::{
 use crate::ecs::resources::{
     LastAcknowledgedUpdate, ServerCommand, UiNetworkCommand, UiNetworkCommandResource,
 };
-use gv_core::ecs::resources::net::MultiplayerRoomPlayer;
 
 const HEARTBEAT_FRAME_INTERVAL: u64 = 10;
 
@@ -337,7 +336,7 @@ impl<'s> System<'s> for ClientNetworkSystem {
                             system_data.last_acknowledged_update.frame_number = 0;
                             system_data.last_acknowledged_update.id = 0;
 
-                            let (entity_net_ids, players): (Vec<u64>, Vec<MultiplayerRoomPlayer>) =
+                            let (entity_net_ids, players): (Vec<NetIdentifier>, Vec<MultiplayerRoomPlayer>) =
                                 net_ids_and_players.into_iter().unzip();
 
                             if let Some(_) = system_data.multiplayer_game_state.read_updated_players() {

--- a/bins/client/src/ecs/systems/client_network.rs
+++ b/bins/client/src/ecs/systems/client_network.rs
@@ -39,6 +39,7 @@ use gv_game::{
 use crate::ecs::resources::{
     LastAcknowledgedUpdate, ServerCommand, UiNetworkCommand, UiNetworkCommandResource,
 };
+use gv_core::ecs::resources::net::MultiplayerRoomPlayer;
 
 const HEARTBEAT_FRAME_INTERVAL: u64 = 10;
 
@@ -200,6 +201,11 @@ impl ClientNetworkSystem {
     }
 }
 
+fn update_room_players(multiplayer_game_state: &mut MultiplayerGameState, players: Vec<MultiplayerRoomPlayer>) {
+    log::info!("Updated room players (player count: {})", players.len());
+    *multiplayer_game_state.update_players() = players;
+}
+
 impl<'s> System<'s> for ClientNetworkSystem {
     type SystemData = ClientNetworkSystemData<'s>;
 
@@ -324,12 +330,20 @@ impl<'s> System<'s> for ClientNetworkSystem {
                             system_data.multiplayer_room_state.is_host = is_host;
                         }
                         ServerMessagePayload::UpdateRoomPlayers(players) => {
-                            log::info!("Updated room players (player count: {})", players.len());
-                            *system_data.multiplayer_game_state.update_players() = players;
+                            update_room_players(&mut system_data.multiplayer_game_state,
+                                                players);
                         }
-                        ServerMessagePayload::StartGame(entity_net_ids) => {
+                        ServerMessagePayload::StartGame(net_ids_and_players) => {
                             system_data.last_acknowledged_update.frame_number = 0;
                             system_data.last_acknowledged_update.id = 0;
+
+                            let (entity_net_ids, players): (Vec<u64>, Vec<MultiplayerRoomPlayer>) =
+                                net_ids_and_players.into_iter().unzip();
+
+                            if let Some(_) = system_data.multiplayer_game_state.read_updated_players() {
+                                update_room_players(&mut system_data.multiplayer_game_state,
+                                                    players);
+                            }
 
                             let connection_id = system_data
                                 .multiplayer_room_state

--- a/bins/client/src/ecs/systems/client_network.rs
+++ b/bins/client/src/ecs/systems/client_network.rs
@@ -200,7 +200,10 @@ impl ClientNetworkSystem {
     }
 }
 
-fn update_room_players(multiplayer_game_state: &mut MultiplayerGameState, players: Vec<MultiplayerRoomPlayer>) {
+fn update_room_players(
+    multiplayer_game_state: &mut MultiplayerGameState,
+    players: Vec<MultiplayerRoomPlayer>,
+) {
     log::info!("Updated room players (player count: {})", players.len());
     *multiplayer_game_state.update_players() = players;
 }
@@ -329,19 +332,24 @@ impl<'s> System<'s> for ClientNetworkSystem {
                             system_data.multiplayer_room_state.is_host = is_host;
                         }
                         ServerMessagePayload::UpdateRoomPlayers(players) => {
-                            update_room_players(&mut system_data.multiplayer_game_state,
-                                                players);
+                            update_room_players(&mut system_data.multiplayer_game_state, players);
                         }
                         ServerMessagePayload::StartGame(net_ids_and_players) => {
                             system_data.last_acknowledged_update.frame_number = 0;
                             system_data.last_acknowledged_update.id = 0;
 
-                            let (entity_net_ids, players): (Vec<NetIdentifier>, Vec<MultiplayerRoomPlayer>) =
-                                net_ids_and_players.into_iter().unzip();
+                            let (entity_net_ids, players): (
+                                Vec<NetIdentifier>,
+                                Vec<MultiplayerRoomPlayer>,
+                            ) = net_ids_and_players.into_iter().unzip();
 
-                            if let Some(_) = system_data.multiplayer_game_state.read_updated_players() {
-                                update_room_players(&mut system_data.multiplayer_game_state,
-                                                    players);
+                            if let Some(_) =
+                                system_data.multiplayer_game_state.read_updated_players()
+                            {
+                                update_room_players(
+                                    &mut system_data.multiplayer_game_state,
+                                    players,
+                                );
                             }
 
                             let connection_id = system_data

--- a/libs/core/src/net/server_message.rs
+++ b/libs/core/src/net/server_message.rs
@@ -15,8 +15,7 @@ pub struct ServerMessage {
 pub enum ServerMessagePayload {
     Heartbeat,
     UpdateRoomPlayers(Vec<MultiplayerRoomPlayer>),
-    /// Must have the same length as a last sent UpdateRoomPlayers,
-    /// contains server (entity) ids for corresponding players.
+    /// Contains pairs of server (entity) ids and their corresponding players.
     StartGame(Vec<(NetIdentifier, MultiplayerRoomPlayer)>),
     Handshake {
         net_id: NetIdentifier,

--- a/libs/core/src/net/server_message.rs
+++ b/libs/core/src/net/server_message.rs
@@ -17,7 +17,7 @@ pub enum ServerMessagePayload {
     UpdateRoomPlayers(Vec<MultiplayerRoomPlayer>),
     /// Must have the same length as a last sent UpdateRoomPlayers,
     /// contains server (entity) ids for corresponding players.
-    StartGame(Vec<NetIdentifier>),
+    StartGame(Vec<(NetIdentifier, MultiplayerRoomPlayer)>),
     Handshake {
         net_id: NetIdentifier,
         is_host: bool,

--- a/libs/game/src/states/playing_state.rs
+++ b/libs/game/src/states/playing_state.rs
@@ -157,7 +157,7 @@ fn initialize_players(world: &mut World) {
                             },
                         )
                         .expect("Expected to insert EntityNetMetadata component");
-                    entity_net_id
+                    (entity_net_id, player.to_owned())
                 })
                 .collect();
             broadcast_message_reliable(


### PR DESCRIPTION
Fixes #44 

- Moved updating client player state to new function `update_room_players`
- Changed `ServerMessagePayload::StartGame` type from `Vec<NetIdentifier>` to `Vec<(NetIdentifier, MultiplayerRoomPlayer)>`
- Changed parsing of `StartGame` in `client_network.rs` to try to update player count

Please let me know if I made any mistakes with the logic or implementation. I was able to reproduce #44 without this change, and I am currently unable to reproduce it after the change. That said, it should be tested further.

Namely, I'm not completely sure whether the `let Some(_) = system_data.multiplayer_game_state.read_updated_players()` should be included.